### PR TITLE
feat: add container setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+coverage
+example/dist
+lib/icons/index.js
+npm-debug.log
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 8080
+CMD ["npm", "run", "start:example"]

--- a/run-container.bat
+++ b/run-container.bat
@@ -1,0 +1,3 @@
+@echo off
+docker build -t bpmn-cpi-simulation .
+docker run --rm -it -p 8080:8080 bpmn-cpi-simulation

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker build -t bpmn-cpi-simulation .
+docker run --rm -it -p 8080:8080 bpmn-cpi-simulation


### PR DESCRIPTION
## Summary
- add Dockerfile to run example app in Node 18 container
- add scripts to build and run the container on Unix and Windows
- ignore unnecessary files in Docker build context

## Testing
- `npm test` *(fails: Cannot start ChromeHeadless due to missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_6891c447c75c832baac551c8eacddb39