### PR TITLE
chore(docker): bundle icons before start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN npm ci
 
 COPY . .
 
+RUN npm run bundle:src
+
 EXPOSE 8080
 CMD ["npm", "run", "start:example"]


### PR DESCRIPTION
## Summary
- build icons during Docker image creation so examples have pre-generated bundle

## Testing
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `docker build -t bpmn-cpi-simulation:test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891caa39318832bbab7c46bd8e199e3