### PR TITLE
feat: make log a resizable left sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the [bpmn-js-token-simulation](https://github.com/bpmn-io
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: make simulation log a resizable left sidebar
+
 ## 0.38.1
 
 * `FIX`: don't show context pad overlays on sub-process plane ([#228](https://github.com/bpmn-io/bpmn-js-token-simulation/pull/228))

--- a/assets/css/bpmn-js-token-simulation.css
+++ b/assets/css/bpmn-js-token-simulation.css
@@ -310,9 +310,9 @@
 
 .bts-log {
   position: absolute;
-  top: 30%;
-  right: 20px;
-  bottom: 50px;
+  top: 0;
+  left: 0;
+  bottom: 0;
   width: 300px;
   background-color: var(--token-simulation-silver-darken-94, #EFEFEF);
   border-radius: 2px;
@@ -353,8 +353,17 @@
   overflow-y: auto;
   box-sizing: border-box;
   flex: 1;
-  margin: 7px 3px 7px 12px;
-  padding: 5px 9px 5px 0;
+  margin: 7px 12px 7px 3px;
+  padding: 5px 0 5px 9px;
+}
+
+.bts-log .bts-log-resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 5px;
+  cursor: ew-resize;
 }
 
 .bts-log *::-webkit-scrollbar {

--- a/lib/features/log/Log.js
+++ b/lib/features/log/Log.js
@@ -356,6 +356,7 @@ export default function Log(
 Log.prototype._init = function() {
   this._container = domify(`
     <div class="bts-log hidden djs-scrollable">
+      <div class="bts-log-resizer" draggable="true"></div>
       <div class="bts-header">
         ${ LogIcon('bts-log-icon') }
         Simulation Log
@@ -387,6 +388,34 @@ Log.prototype._init = function() {
 
   domEvent.bind(this._icon, 'click', () => {
     this.toggle();
+  });
+
+  this._resizer = domQuery('.bts-log-resizer', this._container);
+
+  let startX, startWidth;
+
+  domEvent.bind(this._resizer, 'click', () => {
+    this.toggle(!this.isShown());
+  });
+
+  domEvent.bind(this._resizer, 'dragstart', event => {
+    const img = new Image();
+    img.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    event.dataTransfer.setDragImage(img, 1, 1);
+
+    startX = event.screenX;
+    startWidth = this._container.getBoundingClientRect().width;
+  });
+
+  domEvent.bind(this._resizer, 'drag', event => {
+    if (!event.screenX) {
+      return;
+    }
+
+    const delta = event.screenX - startX;
+    const width = startWidth + delta;
+
+    this._container.style.width = `${width}px`;
   });
 
   this._canvas.getContainer().appendChild(this._container);


### PR DESCRIPTION
## Summary
- add draggable left sidebar for the simulation log
- style log as left-aligned panel with resize handle
- document new sidebar in changelog

## Testing
- `npm test` *(fails: Running as root without --no-sandbox is not supported)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894031e0400832bbe3b3dbd03fbe7c8