### PR TITLE
feat: add theme toggle

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -33,7 +33,7 @@
     }
 
     body {
-      color: #555;
+      color: var(--token-simulation-grey-darken-30);
     }
 
     .link {
@@ -43,6 +43,10 @@
   </style>
 </head>
 <body>
+  <div class="links top-links">
+    <button class="link" id="theme-toggle">🌙</button>
+  </div>
+
   <h1>bpmn-js-token-simulation</h1>
 
   <p>
@@ -52,5 +56,7 @@
   <p style="margin-top: 3em">
     <a class="link" href="viewer.html">Open Viewer</a> or <a class="link" href="modeler.html">Open Modeler</a>
   </p>
+
+  <script src="./theme-toggle.js"></script>
 </body>
 </html>

--- a/example/modeler.html
+++ b/example/modeler.html
@@ -24,6 +24,10 @@
 </head>
 <body>
 
+  <div class="links top-links">
+    <button class="link" id="theme-toggle">🌙</button>
+  </div>
+
   <div class="canvas-parent">
     <div class="canvas" id="canvas">
       <div class="drop-message"><strong>Hint:</strong> Drop a diagram to open</div>
@@ -42,5 +46,6 @@
   </div>
 
   <script src="./dist/modeler.js"></script>
+  <script src="./theme-toggle.js"></script>
 </body>
 </html>

--- a/example/style.css
+++ b/example/style.css
@@ -1,5 +1,12 @@
 /** link styles */
 
+:root {
+  --token-simulation-grey-darken-30: #212121;
+  --token-simulation-silver-darken-94: #EFEFEF;
+  --token-simulation-white: #FFFFFF;
+  --token-simulation-green-base-44: #10D070;
+}
+
 html, body, #canvas {
   width: 100%;
   height: 100%;
@@ -10,6 +17,13 @@ html, body, #canvas {
   font-size: 12px;
 
   color: var(--token-simulation-grey-darken-30, #212121);
+  background-color: var(--token-simulation-white, #FFFFFF);
+}
+
+body.dark-mode {
+  --token-simulation-grey-darken-30: #f1f1f1;
+  --token-simulation-silver-darken-94: #555555;
+  --token-simulation-white: #2e2e2e;
 }
 
 body:not(.presentation-mode) .bts-notifications {

--- a/example/theme-toggle.js
+++ b/example/theme-toggle.js
@@ -1,0 +1,20 @@
+window.addEventListener('DOMContentLoaded', function() {
+  var toggle = document.getElementById('theme-toggle');
+  if (!toggle) {
+    return;
+  }
+
+  function applyTheme(theme) {
+    document.body.classList.toggle('dark-mode', theme === 'dark');
+    toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+  }
+
+  var saved = localStorage.getItem('theme') || 'light';
+  applyTheme(saved);
+
+  toggle.addEventListener('click', function() {
+    var next = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+    localStorage.setItem('theme', next);
+    applyTheme(next);
+  });
+});

--- a/example/viewer.html
+++ b/example/viewer.html
@@ -22,6 +22,10 @@
   <meta property="og:image" content="https://bpmn-io.github.io/bpmn-js-token-simulation/screenshot.png" />
 </head>
 <body>
+  <div class="links top-links">
+    <button class="link" id="theme-toggle">🌙</button>
+  </div>
+
   <div class="canvas-parent">
     <div class="canvas" id="canvas">
       <div class="drop-message"><strong>Hint:</strong> Drop a diagram to open</div>
@@ -30,5 +34,6 @@
   </div>
 
   <script src="./dist/viewer.js"></script>
+  <script src="./theme-toggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add light/dark theme toggle with sun/moon button across examples
- store user preference and use a moderately dark palette

## Testing
- `npm run lint`
- `npm test` *(fails: ChromeHeadless missing libXcomposite.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_689405c4c948832b81b41a686baa8d25