### PR TITLE
feat(example): add dark mode styling for BPMN canvas

### DIFF
--- a/example/style.css
+++ b/example/style.css
@@ -26,6 +26,15 @@ body.dark-mode {
   --token-simulation-white: #2e2e2e;
 }
 
+.dark-mode .djs-container {
+  background-color: var(--token-simulation-white, #FFFFFF);
+}
+
+.dark-mode .djs-container .djs-element {
+  fill: var(--token-simulation-silver-darken-94, #EFEFEF);
+  stroke: var(--token-simulation-grey-darken-30, #212121);
+}
+
 body:not(.presentation-mode) .bts-notifications {
   bottom: 60px;
 }


### PR DESCRIPTION
## Summary
- extend dark mode support by styling BPMN canvas and elements with existing color variables

## Testing
- `npm run lint`
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689409f33c0c832ba7f02ecf67d814eb