### PR TITLE
feat(example): preload theme before DOM ready

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -5,6 +5,12 @@
 
   <title>BPMN Token Simulation Demo</title>
 
+  <script>
+    if (localStorage.getItem('theme') === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
+
   <link rel="stylesheet" href="./style.css" />
 
   <link rel="icon" type="image/png" href="favicon.png" />

--- a/example/modeler.html
+++ b/example/modeler.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8">
 
   <title>Modeler | BPMN Token Simulation Demo</title>
+  <script>
+    if (localStorage.getItem('theme') === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
 
   <link rel="stylesheet" href="./dist/vendor/bpmn-js/assets/diagram-js.css" />
   <link rel="stylesheet" href="./dist/vendor/bpmn-js/assets/bpmn-js.css" />

--- a/example/style.css
+++ b/example/style.css
@@ -20,6 +20,7 @@ html, body, #canvas {
   background-color: var(--token-simulation-white, #FFFFFF);
 }
 
+html.dark-mode,
 body.dark-mode {
   --token-simulation-grey-darken-30: #f1f1f1;
   --token-simulation-silver-darken-94: #555555;

--- a/example/theme-toggle.js
+++ b/example/theme-toggle.js
@@ -1,20 +1,40 @@
-window.addEventListener('DOMContentLoaded', function() {
-  var toggle = document.getElementById('theme-toggle');
-  if (!toggle) {
-    return;
-  }
+(function() {
+  var toggle;
+  var theme = localStorage.getItem('theme') || 'light';
 
   function applyTheme(theme) {
-    document.body.classList.toggle('dark-mode', theme === 'dark');
-    toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+    document.documentElement.classList.toggle('dark-mode', theme === 'dark');
+
+    if (toggle) {
+      toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+      toggle.setAttribute('aria-label', theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    }
   }
 
-  var saved = localStorage.getItem('theme') || 'light';
-  applyTheme(saved);
+  applyTheme(theme);
 
-  toggle.addEventListener('click', function() {
-    var next = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
-    localStorage.setItem('theme', next);
-    applyTheme(next);
-  });
-});
+  function init() {
+    toggle = document.getElementById('theme-toggle');
+
+    if (!toggle) {
+      return;
+    }
+
+    applyTheme(theme);
+
+    toggle.addEventListener('click', function() {
+      theme = document.documentElement.classList.contains('dark-mode') ? 'light' : 'dark';
+
+      localStorage.setItem('theme', theme);
+
+      applyTheme(theme);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+

--- a/example/viewer.html
+++ b/example/viewer.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8">
 
   <title>Viewer | BPMN Token Simulation Demo</title>
+  <script>
+    if (localStorage.getItem('theme') === 'dark') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
 
   <link rel="stylesheet" href="./dist/vendor/bpmn-js/assets/diagram-js.css" />
   <link rel="stylesheet" href="./dist/vendor/bpmn-js/assets/bpmn-js.css" />


### PR DESCRIPTION
## Summary
- apply saved theme immediately from localStorage to avoid flash of incorrect theme
- adjust theme toggle to update icon and aria-label for current theme
- add inline theme preload script to example pages

## Testing
- `npm run lint`
- `npm test` *(fails: ChromeHeadless cannot start without --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_689409f4fa80832ba37efec8e057b609