### PR TITLE
feat: add color picker support to modeler example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,22 @@ Add as additional module to [bpmn-js](https://github.com/bpmn-io/bpmn-js).
 import BpmnModeler from 'bpmn-js/lib/Modeler';
 import TokenSimulationModule from 'bpmn-js-token-simulation';
 
+// optional color picker support
+import ColorPickerModule from 'bpmn-js-color-picker';
+
 const modeler = new BpmnModeler({
   container: '#canvas',
   additionalModules: [
-    TokenSimulationModule
+    TokenSimulationModule,
+    ColorPickerModule
   ]
 });
+```
+
+Include the color picker stylesheet in your page:
+
+```html
+<link rel="stylesheet" href="node_modules/bpmn-js-color-picker/colors/color-picker.css" />
 ```
 
 ### Viewer

--- a/example/modeler.html
+++ b/example/modeler.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="./dist/vendor/bpmn-js/assets/bpmn-font/css/bpmn-embedded.css" />
   <link rel="stylesheet" href="./dist/vendor/bpmn-js-token-simulation/assets/css/bpmn-js-token-simulation.css" />
   <link rel="stylesheet" href="./dist/vendor/bpmn-js-properties-panel/assets/properties-panel.css" />
+  <link rel="stylesheet" href="./dist/vendor/bpmn-js-color-picker/colors/color-picker.css" />
   <link rel="stylesheet" href="./style.css" />
 
   <link rel="icon" type="image/png" href="favicon.png" />

--- a/example/src/modeler.js
+++ b/example/src/modeler.js
@@ -17,6 +17,8 @@ import fileOpen from 'file-open';
 
 import download from 'downloadjs';
 
+import ColorPickerModule from 'bpmn-js-color-picker';
+
 import exampleXML from '../resources/example.bpmn';
 
 const url = new URL(window.location.href);
@@ -95,6 +97,7 @@ const modeler = new BpmnModeler({
     BpmnPropertiesProviderModule,
     TokenSimulationModule,
     AddExporter,
+    ColorPickerModule,
     ExampleModule
   ],
   propertiesPanel: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.38.1",
       "license": "MIT",
       "dependencies": {
+        "bpmn-js-color-picker": "^0.7.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^4.2.2",
         "min-dom": "^4.2.1",
@@ -436,7 +437,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
-      "dev": true,
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -2544,7 +2544,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.2.0.tgz",
       "integrity": "sha512-2wdOUe2WjR+hvDsHorzNyIe52Ep8l1a79FJPQsss0fm2Jrjx/Sf9hRs+C3cKIbogBTZPQkmuS/QoCFjniMevzg==",
-      "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^9.0.1",
@@ -2558,6 +2557,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bpmn-js-color-picker": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-color-picker/-/bpmn-js-color-picker-0.7.2.tgz",
+      "integrity": "sha512-V3Gusxgx+Y6uEh3gg2Jpqd92au0kjfad6ETSNa7U0p2/hqlpYj8RWGwqjUui9tghkTg0mlKaqs6KZ8Lvxzn0pg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 14"
       }
     },
     "node_modules/bpmn-js-properties-panel": {
@@ -2587,7 +2598,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
       "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
-      "dev": true,
       "dependencies": {
         "min-dash": "^4.2.1",
         "moddle": "^7.0.0",
@@ -2932,7 +2942,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
       "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3524,7 +3533,6 @@
       "version": "15.2.4",
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.2.4.tgz",
       "integrity": "sha512-8v0U8AY6a5Vd6Cys5MdN7+yYRhs294/Q4ixkER/3v2ZPSbVCnK9XfbeYbB5QQfoCMkBnY7WBbLbcjvRNHTxnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
@@ -3545,7 +3553,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.2.0.tgz",
       "integrity": "sha512-+pyxeQGBSdLiZX0/tmmsm2qZSvm9YtVzod5W3RMHSTR7VrkUMD6E7EX/W9JQv3ebxO7oIdqFmytmNDDpSHnYEw==",
-      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.2.1"
@@ -3561,7 +3568,6 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
       "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
-      "dev": true,
       "engines": {
         "node": ">= 16"
       }
@@ -5393,8 +5399,7 @@
     "node_modules/htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "dev": true
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5559,8 +5564,7 @@
     "node_modules/ids": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
-      "dev": true
+      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
     },
     "node_modules/ignore": {
       "version": "5.3.0",
@@ -7215,7 +7219,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
       "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
-      "dev": true,
       "dependencies": {
         "min-dash": "^4.2.1"
       }
@@ -7224,7 +7227,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
       "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
-      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0",
         "saxen": "^10.0.0"
@@ -7481,7 +7483,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
       "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7765,7 +7766,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
       "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
-      "dev": true,
       "engines": {
         "node": ">= 14.20"
       }
@@ -7932,7 +7932,6 @@
       "version": "10.20.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.1.tgz",
       "integrity": "sha512-JIFjgFg9B2qnOoGiYMVBtrcFxHqn+dNXbq76bVmcaHYJFYR4lW67AOcXgAYQQTDYXDOg/kTZrKPNCdRgJ2UJmw==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -8521,7 +8520,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
       "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
-      "dev": true,
       "engines": {
         "node": ">= 18"
       }
@@ -9472,8 +9470,7 @@
     "node_modules/tiny-svg": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.2.tgz",
-      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw==",
-      "dev": true
+      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.12",
@@ -10826,7 +10823,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
-      "dev": true,
       "requires": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -12393,7 +12389,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.2.0.tgz",
       "integrity": "sha512-2wdOUe2WjR+hvDsHorzNyIe52Ep8l1a79FJPQsss0fm2Jrjx/Sf9hRs+C3cKIbogBTZPQkmuS/QoCFjniMevzg==",
-      "dev": true,
       "requires": {
         "bpmn-moddle": "^9.0.1",
         "diagram-js": "^15.2.4",
@@ -12404,6 +12399,12 @@
         "min-dom": "^4.2.1",
         "tiny-svg": "^3.1.2"
       }
+    },
+    "bpmn-js-color-picker": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-color-picker/-/bpmn-js-color-picker-0.7.2.tgz",
+      "integrity": "sha512-V3Gusxgx+Y6uEh3gg2Jpqd92au0kjfad6ETSNa7U0p2/hqlpYj8RWGwqjUui9tghkTg0mlKaqs6KZ8Lvxzn0pg==",
+      "requires": {}
     },
     "bpmn-js-properties-panel": {
       "version": "5.31.1",
@@ -12422,7 +12423,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
       "integrity": "sha512-jO2P5RBx0cZCCd+imqhpNE5anttaYuGd71u76NEA/qMZwJSW1t5ETAtw9/E2InfiPU2w0TR8oxPyopJXRc9VQg==",
-      "dev": true,
       "requires": {
         "min-dash": "^4.2.1",
         "moddle": "^7.0.0",
@@ -12659,8 +12659,7 @@
     "clsx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-      "dev": true
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -13089,7 +13088,6 @@
       "version": "15.2.4",
       "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.2.4.tgz",
       "integrity": "sha512-8v0U8AY6a5Vd6Cys5MdN7+yYRhs294/Q4ixkER/3v2ZPSbVCnK9XfbeYbB5QQfoCMkBnY7WBbLbcjvRNHTxnpw==",
-      "dev": true,
       "requires": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -13106,7 +13104,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.2.0.tgz",
       "integrity": "sha512-+pyxeQGBSdLiZX0/tmmsm2qZSvm9YtVzod5W3RMHSTR7VrkUMD6E7EX/W9JQv3ebxO7oIdqFmytmNDDpSHnYEw==",
-      "dev": true,
       "requires": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.2.1"
@@ -13115,8 +13112,7 @@
     "didi": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
-      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
-      "dev": true
+      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w=="
     },
     "diff": {
       "version": "5.2.0",
@@ -14458,8 +14454,7 @@
     "htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
-      "dev": true
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -14582,8 +14577,7 @@
     "ids": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
-      "dev": true
+      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
     },
     "ignore": {
       "version": "5.3.0",
@@ -15786,7 +15780,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-7.0.0.tgz",
       "integrity": "sha512-Hpte2hfKDwoZWPvDngsEHjloPnO+sKMUVkAPc0r9PrpnVLqsyPUTV0ZQU8CAp87YmRZ9QzeQMJxdKbaP9vEIKA==",
-      "dev": true,
       "requires": {
         "min-dash": "^4.2.1"
       }
@@ -15795,7 +15788,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-11.0.0.tgz",
       "integrity": "sha512-L3Sseepfcq9Uy0iIfqEDTXSoYLva1Y/JGbN/4AMOeQ6cqbu8Ma/SDJIdOFm7smsAa64j2z3SwCGG3FIilQVnUg==",
-      "dev": true,
       "requires": {
         "min-dash": "^4.0.0",
         "saxen": "^10.0.0"
@@ -15987,8 +15979,7 @@
     "object-refs": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
-      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
-      "dev": true
+      "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ=="
     },
     "object.assign": {
       "version": "4.1.5",
@@ -16188,8 +16179,7 @@
     "path-intersection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.0.0.tgz",
-      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA==",
-      "dev": true
+      "integrity": "sha512-Rdnfb33F9+qadWe3ZyzDpw3KSXQhsK1MByL44QzSDIQtMAujd0zFx9f+kt4SaQp1JOoXl5pl5K28EoEuAEgarA=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -16305,8 +16295,7 @@
     "preact": {
       "version": "10.20.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.1.tgz",
-      "integrity": "sha512-JIFjgFg9B2qnOoGiYMVBtrcFxHqn+dNXbq76bVmcaHYJFYR4lW67AOcXgAYQQTDYXDOg/kTZrKPNCdRgJ2UJmw==",
-      "dev": true
+      "integrity": "sha512-JIFjgFg9B2qnOoGiYMVBtrcFxHqn+dNXbq76bVmcaHYJFYR4lW67AOcXgAYQQTDYXDOg/kTZrKPNCdRgJ2UJmw=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -16745,8 +16734,7 @@
     "saxen": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
-      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g==",
-      "dev": true
+      "integrity": "sha512-RXsmWok/SAWqOG/f5ADEz51DN9WtZEzqih3e08ranldcaXekxjx8NBKjGh/y5hlowjo0JH/LekBu6gtPFD1G6g=="
     },
     "schema-utils": {
       "version": "4.2.0",
@@ -17455,8 +17443,7 @@
     "tiny-svg": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.2.tgz",
-      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw==",
-      "dev": true
+      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw=="
     },
     "tinyglobby": {
       "version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "webpack-dev-server": "^5.2.0"
   },
   "dependencies": {
+    "bpmn-js-color-picker": "^0.7.2",
     "inherits-browser": "^0.1.0",
     "min-dash": "^4.2.2",
     "min-dom": "^4.2.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,8 @@ module.exports = (env, argv) => {
         patterns: [
           { from: './assets', to: 'dist/vendor/bpmn-js-token-simulation/assets' },
           { from: 'bpmn-js/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js/assets' },
-          { from: '@bpmn-io/properties-panel/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js-properties-panel/assets' }
+          { from: '@bpmn-io/properties-panel/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js-properties-panel/assets' },
+          { from: 'bpmn-js-color-picker/colors/color-picker.css', context: 'node_modules', to: 'dist/vendor/bpmn-js-color-picker/colors/color-picker.css' }
         ]
       }),
       new DefinePlugin({


### PR DESCRIPTION
## Summary
- add `bpmn-js-color-picker` dependency
- wire up color picker module and styles in the example
- document color picker usage in the README

## Testing
- `npm run bundle:src`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68940ec8952c832b9044066ab4d8cbdb