### PR TITLE
feat(example): add sketchy theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ import TokenSimulationModule from 'bpmn-js-token-simulation';
 
 // optional color picker support
 import ColorPickerModule from 'bpmn-js-color-picker';
+// optional sketchy theme
+import SketchyModule from 'bpmn-js-sketchy';
 
 const modeler = new BpmnModeler({
   container: '#canvas',
   additionalModules: [
     TokenSimulationModule,
-    ColorPickerModule
+    ColorPickerModule,
+    SketchyModule
   ]
 });
 ```
@@ -45,6 +48,9 @@ Include the color picker stylesheet in your page:
 ```html
 <link rel="stylesheet" href="node_modules/bpmn-js-color-picker/colors/color-picker.css" />
 ```
+
+To customize the sketchy appearance, override the `--bpmn-sketchy-font` CSS variable in your stylesheet. Remove
+`SketchyModule` from `additionalModules` to switch back to the default renderer.
 
 ### Viewer
 

--- a/example/src/modeler.js
+++ b/example/src/modeler.js
@@ -1,3 +1,4 @@
+
 /* global process */
 
 import TokenSimulationModule from '../..';
@@ -18,6 +19,7 @@ import fileOpen from 'file-open';
 import download from 'downloadjs';
 
 import ColorPickerModule from 'bpmn-js-color-picker';
+import SketchyModule from 'bpmn-js-sketchy';
 
 import exampleXML from '../resources/example.bpmn';
 
@@ -98,6 +100,7 @@ const modeler = new BpmnModeler({
     TokenSimulationModule,
     AddExporter,
     ColorPickerModule,
+    SketchyModule,
     ExampleModule
   ],
   propertiesPanel: {

--- a/example/style.css
+++ b/example/style.css
@@ -5,6 +5,7 @@
   --token-simulation-silver-darken-94: #EFEFEF;
   --token-simulation-white: #FFFFFF;
   --token-simulation-green-base-44: #10D070;
+  --bpmn-sketchy-font: 'Comic Sans MS', cursive;
 }
 
 html, body, #canvas {
@@ -18,6 +19,13 @@ html, body, #canvas {
 
   color: var(--token-simulation-grey-darken-30, #212121);
   background-color: var(--token-simulation-white, #FFFFFF);
+}
+
+/* sketchy theme font */
+.djs-container,
+.djs-container .djs-element text,
+.djs-direct-editing-content {
+  font-family: var(--bpmn-sketchy-font, 'Comic Sans MS', cursive);
 }
 
 html.dark-mode,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bpmn-js-color-picker": "^0.7.2",
+        "bpmn-js-sketchy": "^0.7.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^4.2.2",
         "min-dom": "^4.2.1",
@@ -2592,6 +2593,23 @@
         "bpmn-js": ">= 11.5",
         "camunda-bpmn-js-behaviors": ">= 0.4",
         "diagram-js": ">= 11.9"
+      }
+    },
+    "node_modules/bpmn-js-sketchy": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-sketchy/-/bpmn-js-sketchy-0.7.2.tgz",
+      "integrity": "sha512-hhWCaG1IZaw/f90CbqkFyaUaOZ59lGqjqrGM53vCLMyY0J6uOSl+jzbOtMUE+ij3/exgAe1wN3amSzqpfEAipg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.3",
+        "roughjs": "^4.5.2",
+        "tiny-svg": "^3.0.0"
+      },
+      "peerDependencies": {
+        "bpmn-js": ">= 11",
+        "diagram-js": ">= 11"
       }
     },
     "node_modules/bpmn-moddle": {
@@ -5258,6 +5276,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -7753,6 +7777,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7917,6 +7947,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8449,6 +8495,18 @@
       "dev": true,
       "dependencies": {
         "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
       }
     },
     "node_modules/run-applescript": {
@@ -12419,6 +12477,18 @@
         "min-dom": "^4.2.1"
       }
     },
+    "bpmn-js-sketchy": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/bpmn-js-sketchy/-/bpmn-js-sketchy-0.7.2.tgz",
+      "integrity": "sha512-hhWCaG1IZaw/f90CbqkFyaUaOZ59lGqjqrGM53vCLMyY0J6uOSl+jzbOtMUE+ij3/exgAe1wN3amSzqpfEAipg==",
+      "requires": {
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.3",
+        "roughjs": "^4.5.2",
+        "tiny-svg": "^3.0.0"
+      }
+    },
     "bpmn-moddle": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-9.0.1.tgz",
@@ -14344,6 +14414,11 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -16170,6 +16245,11 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
+    "path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -16284,6 +16364,20 @@
             "p-limit": "^2.2.0"
           }
         }
+      }
+    },
+    "points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="
+    },
+    "points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "requires": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "possible-typed-array-names": {
@@ -16680,6 +16774,17 @@
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
+      }
+    },
+    "roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "requires": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
       }
     },
     "run-applescript": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "dependencies": {
     "bpmn-js-color-picker": "^0.7.2",
+    "bpmn-js-sketchy": "^0.7.2",
     "inherits-browser": "^0.1.0",
     "min-dash": "^4.2.2",
     "min-dom": "^4.2.1",


### PR DESCRIPTION
## Summary
- add bpmn-js-sketchy dependency for sketchy theme support
- wire sketchy renderer into example modeler and expose font variable
- document how to enable and customize the sketchy theme

## Testing
- `npm test` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689414f134c8832b98d5981b4fb7aea8