### PR TITLE
feat: make run-container port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ npm run start:basic
 ```
 
 
+To run the project inside a Docker container use:
+
+```sh
+./run-container.sh [port]
+```
+
+The script binds the application to port `8081` by default and checks whether the port is free.
+If the port is already in use, specify a different one:
+
+```sh
+./run-container.sh 9090
+```
+
+
 ## BPMN Linting
 
 The example modeler ships with [bpmnlint](https://github.com/bpmn-io/bpmnlint) support.

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
+set -e
+
+PORT="${1:-8081}"
+
+# check if port is available
+if command -v nc >/dev/null; then
+  if nc -z localhost "$PORT" 2>/dev/null; then
+    echo "Port $PORT is already in use."
+    echo "Use: $0 <port> to specify a different host port."
+    exit 1
+  fi
+fi
+
 docker build -t bpmn-cpi-simulation .
-docker run --rm -it -p 8081:8080 bpmn-cpi-simulation
+docker run --rm -it -p "$PORT":8080 bpmn-cpi-simulation


### PR DESCRIPTION
## Summary
- allow passing a custom port to `run-container.sh` (default 8081)
- warn and exit if requested port is already taken
- document container run script and port override in README

## Testing
- `npm install` *(fails: @bpmn-io/diagram-js-theme not in registry)*
- `npm test` *(fails: karma not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_689419b7a3d0832b90c9ee859f22b542