### PR TITLE
chore: replace diagram theme dependency

### DIFF
--- a/example/src/modeler.js
+++ b/example/src/modeler.js
@@ -17,7 +17,7 @@ import fileDrop from 'file-drops';
 import fileOpen from 'file-open';
 
 import download from 'downloadjs';
-import DiagramTheme from '@bpmn-io/diagram-js-theme';
+import gridModule from 'diagram-js-grid';
 import ColorPickerModule from 'bpmn-js-color-picker';
 import SketchyModule from 'bpmn-js-sketchy';
 import minimapModule from 'diagram-js-minimap';
@@ -102,7 +102,7 @@ const modeler = new BpmnModeler({
     AddExporter,
     ColorPickerModule,
     SketchyModule,
-    DiagramTheme,
+    gridModule,
     ExampleModule,
     minimapModule,
     BpmnLintModule

--- a/example/src/viewer.js
+++ b/example/src/viewer.js
@@ -9,7 +9,7 @@ import fileOpen from 'file-open';
 import exampleXML from '../resources/example.bpmn';
 import minimapModule from 'diagram-js-minimap';
 
-import DiagramTheme from '@bpmn-io/diagram-js-theme';
+import gridModule from 'diagram-js-grid';
 
 
 const url = new URL(window.location.href);
@@ -82,7 +82,7 @@ const viewer = new BpmnViewer({
   additionalModules: [
     ExampleModule,
     TokenSimulationModule,
-    DiagramTheme,
+    gridModule,
     minimapModule
   ]
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bpmn-js-color-picker": "^0.7.2",
         "bpmn-js-sketchy": "^0.7.2",
+        "diagram-js-grid": "^1.1.0",
         "diagram-js-minimap": "^5.2.0",
         "inherits-browser": "^0.1.0",
         "min-dash": "^4.2.2",
@@ -3673,6 +3674,16 @@
       },
       "peerDependencies": {
         "diagram-js": "*"
+      }
+    },
+    "node_modules/diagram-js-grid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-grid/-/diagram-js-grid-1.1.0.tgz",
+      "integrity": "sha512-hnqRrWjbMA8YsBqaJe/GVIyJBITPSmUfsQVfN78jjtn1Elw5FZu838kVYQ/+FBOaTOxFixjyKgSGXc847uH2JA==",
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^4.1.1",
+        "tiny-svg": "^3.0.1"
       }
     },
     "node_modules/diagram-js-minimap": {
@@ -8077,6 +8088,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -8091,16 +8112,6 @@
       "dependencies": {
         "path-data-parser": "0.1.0",
         "points-on-curve": "0.2.0"
-      }
-    },
-    "node_modules/pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -13392,6 +13403,15 @@
         "min-dom": "^4.2.1"
       }
     },
+    "diagram-js-grid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagram-js-grid/-/diagram-js-grid-1.1.0.tgz",
+      "integrity": "sha512-hnqRrWjbMA8YsBqaJe/GVIyJBITPSmUfsQVfN78jjtn1Elw5FZu838kVYQ/+FBOaTOxFixjyKgSGXc847uH2JA==",
+      "requires": {
+        "min-dash": "^4.1.1",
+        "tiny-svg": "^3.0.1"
+      }
+    },
     "diagram-js-minimap": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diagram-js-minimap/-/diagram-js-minimap-5.2.0.tgz",
@@ -16607,6 +16627,12 @@
         }
       }
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
     "points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -16620,12 +16646,6 @@
         "path-data-parser": "0.1.0",
         "points-on-curve": "0.2.0"
       }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
     },
     "possible-typed-array-names": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -92,11 +92,11 @@
   "dependencies": {
     "bpmn-js-color-picker": "^0.7.2",
     "bpmn-js-sketchy": "^0.7.2",
+    "diagram-js-grid": "^1.1.0",
     "diagram-js-minimap": "^5.2.0",
     "inherits-browser": "^0.1.0",
     "min-dash": "^4.2.2",
     "min-dom": "^4.2.1",
-    "randomcolor": "^0.6.2",
-    "@bpmn-io/diagram-js-theme": "^0.7.0"
+    "randomcolor": "^0.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- replace unavailable `@bpmn-io/diagram-js-theme` with `diagram-js-grid`
- update examples to use the grid module

## Testing
- `npm ci --no-audit --no-fund`
- `npm test` *(fails: ChromeHeadless failed to start: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689419b6e0e0832b9022380d1d240ca2