### PR TITLE
refactor: replace node-based image export

### DIFF
--- a/example/src/modeler.js
+++ b/example/src/modeler.js
@@ -17,7 +17,7 @@ import fileDrop from 'file-drops';
 import fileOpen from 'file-open';
 
 import download from 'downloadjs';
-import { toPNG, toSVG } from 'bpmn-to-image';
+import { svgToPng } from './utils';
 import gridModule from 'diagram-js-grid';
 import ColorPickerModule from 'bpmn-js-color-picker';
 import SketchyModule from 'bpmn-js-sketchy';
@@ -180,7 +180,7 @@ function downloadDiagram() {
 
 function exportPNG() {
   modeler.saveSVG().then(({ svg }) => {
-    toPNG(svg).then(png => {
+    svgToPng(svg).then(png => {
       download(png, fileName.replace(/\.bpmn$/i, '.png'), 'image/png');
     });
   });
@@ -188,9 +188,7 @@ function exportPNG() {
 
 function exportSVG() {
   modeler.saveSVG().then(({ svg }) => {
-    toSVG(svg).then(svgData => {
-      download(svgData, fileName.replace(/\.bpmn$/i, '.svg'), 'image/svg+xml');
-    });
+    download(svg, fileName.replace(/\.bpmn$/i, '.svg'), 'image/svg+xml');
   });
 }
 

--- a/example/src/utils.js
+++ b/example/src/utils.js
@@ -1,0 +1,22 @@
+export function svgToPng(svg) {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    const blob = new Blob([ svg ], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+
+    image.onload = function() {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.width;
+      canvas.height = image.height;
+      const context = canvas.getContext('2d');
+      context.drawImage(image, 0, 0);
+      URL.revokeObjectURL(url);
+      canvas.toBlob(function(blob) {
+        resolve(blob);
+      }, 'image/png');
+    };
+
+    image.onerror = reject;
+    image.src = url;
+  });
+}

--- a/example/src/viewer.js
+++ b/example/src/viewer.js
@@ -11,7 +11,7 @@ import minimapModule from 'diagram-js-minimap';
 
 import gridModule from 'diagram-js-grid';
 import download from 'downloadjs';
-import { toPNG, toSVG } from 'bpmn-to-image';
+import { svgToPng } from './utils';
 
 
 const url = new URL(window.location.href);
@@ -130,7 +130,7 @@ function openFile(files) {
 
 function exportPNG() {
   viewer.saveSVG().then(({ svg }) => {
-    toPNG(svg).then(png => {
+    svgToPng(svg).then(png => {
       download(png, fileName.replace(/\.bpmn$/i, '.png'), 'image/png');
     });
   });
@@ -138,9 +138,7 @@ function exportPNG() {
 
 function exportSVG() {
   viewer.saveSVG().then(({ svg }) => {
-    toSVG(svg).then(svgData => {
-      download(svgData, fileName.replace(/\.bpmn$/i, '.svg'), 'image/svg+xml');
-    });
+    download(svg, fileName.replace(/\.bpmn$/i, '.svg'), 'image/svg+xml');
   });
 }
 


### PR DESCRIPTION
## Summary
- drop Node-only `bpmn-to-image` from examples
- add browser-based `svgToPng` helper for image downloads
- simplify PNG and SVG export helpers

## Testing
- `npm run lint`
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_689431d9b658832b9522fbe69be228c7