### PR TITLE
chore: wire BPMN linting and plugin build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to the [bpmn-js-token-simulation](https://github.com/bpmn-io
 ___Note:__ Yet to be released changes appear here._
 
 * `FEAT`: make simulation log a resizable left sidebar
-* `CHORE`: add BPMN linting via `npm run lint:bpmn` and include it in `npm test`
-* `CHORE`: bundle BPMN lint plugin assets during build
+* `CHORE`: lint all BPMN diagrams via `npm run lint:bpmn` and run it with `npm test`
+* `CHORE`: bundle BPMN lint plugin assets and configuration during build
 
 ## 0.38.1
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "run-s lint:js lint:bpmn",
     "lint:js": "eslint .",
     "lint:bpmn": "bpmnlint \"example/**/*.bpmn\"",
-    "test": "run-s lint test:unit",
+    "test": "run-s lint:js lint:bpmn test:unit",
     "test:unit": "karma start",
     "dev": "npm test -- --auto-watch --no-single-run"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,13 +6,14 @@ export default {
   input: 'src/icons/index.js',
   output: {
     file: 'lib/icons/index.js',
-    format: 'esm'
+    format: 'esm',
+    sourcemap: true
   },
   plugins: [
     string({
       include: '**/*.svg'
     }),
-    nodeResolve(),
+    nodeResolve({ browser: true }),
     commonjs()
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,8 @@ module.exports = (env, argv) => {
           { from: '@bpmn-io/properties-panel/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js-properties-panel/assets' },
           { from: 'bpmn-js-bpmnlint/dist/assets', context: 'node_modules', to: 'dist/vendor/bpmn-js-bpmnlint/assets' },
           { from: 'bpmn-js-color-picker/colors/color-picker.css', context: 'node_modules', to: 'dist/vendor/bpmn-js-color-picker/colors/color-picker.css' },
-          { from: 'diagram-js-minimap/assets/diagram-js-minimap.css', context: 'node_modules', to: 'dist/vendor/diagram-js-minimap/assets/diagram-js-minimap.css' }
+          { from: 'diagram-js-minimap/assets/diagram-js-minimap.css', context: 'node_modules', to: 'dist/vendor/diagram-js-minimap/assets/diagram-js-minimap.css' },
+          { from: '.bpmnlintrc', to: '.bpmnlintrc', noErrorOnMissing: true }
         ]
       }),
       new DefinePlugin({


### PR DESCRIPTION
## Summary
- run bpmnlint and eslint before tests
- emit source maps and browser-resolve icon bundle
- copy bpmnlint config and assets in build output

## Testing
- `npm run lint`
- `npm test` *(fails: ChromeHeadless requires --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_689434e1ac9c832b994e162f91f121a0